### PR TITLE
Add settings to support shir high-availability and auto-expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ az deployment group create \
   --parameters 'vmAdminPassword=<YOUR-VM-ADMIN-PASSWORD>' ['irNodeExpirationTime=<TIME-IN-SECONDS>']
 ```
 
-where the optional parameter `irNodeExpirationTime` specifies the time in seconds when the offline nodes expire after App Service stops or restarts. The expired nodes will be removed automatically during next restarting. The minimum expiration time, as well as the default value, is 600 seconds (10 minute).
+where the optional parameter `irNodeExpirationTime` specifies the time in seconds when the offline nodes expire after App Service stops or restarts. The expired nodes will be removed automatically during next restarting. The minimum expiration time, as well as the default value, is 600 seconds (10 minutes).
 
 The deployment takes approximately 30-45 minutes to complete. The majority of this time is the step to build the container image within Azure Container Registry.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Next, initiate the deployment of the Bicep file. The only mandatory parameter is
 az deployment group create \
   --resource-group SHIR \
   --template-file deploy/main.bicep \
-  --parameters 'vmAdminPassword=<YOUR-VM-ADMIN-PASSWORD>'
+  --parameters 'vmAdminPassword=<YOUR-VM-ADMIN-PASSWORD>' ['irNodeExpirationTime=<TIME-IN-SECONDS>']
 ```
+
+where the optional parameter `irNodeExpirationTime` specifies the time in seconds when the offline nodes expire after App Service stops or restarts. The expired nodes will be removed automatically during next restarting. The minimum expiration time, as well as the default value, is 600 seconds (10 minute).
 
 The deployment takes approximately 30-45 minutes to complete. The majority of this time is the step to build the container image within Azure Container Registry.
 

--- a/deploy/main.bicep
+++ b/deploy/main.bicep
@@ -19,6 +19,12 @@ param appServicePlanSku object = {
   capacity: 1
 }
 
+@description('The port for nodes remote access.')
+param irNodeRemoteAccessPort int = 8060
+
+@description('The expiration time of the offline nodes in seconds. The value should not be less than 600.')
+param irNodeExpirationTime int = 600
+
 @description('The name of the SKU to use when creating the virtual machine.')
 param vmSize string = 'Standard_DS1_v2'
 
@@ -114,6 +120,8 @@ module app 'modules/app.bicep' = {
     containerImageTag: acr.outputs.containerImageTag
     dataFactoryName: adf.outputs.dataFactoryName
     dataFactoryIntegrationRuntimeName: adf.outputs.integrationRuntimeName
+    irNodeRemoteAccessPort: irNodeRemoteAccessPort
+    irNodeExpirationTime: irNodeExpirationTime
     appServicePlanSku: appServicePlanSku
   }
 }

--- a/deploy/modules/app.bicep
+++ b/deploy/modules/app.bicep
@@ -37,6 +37,12 @@ param dataFactoryIntegrationRuntimeName string
 @description('The name of the node to create for the self-hosted integration runtime.')
 param dataFactoryIntegrationRuntimeNodeName string = 'AppServiceContainer'
 
+@description('The port for nodes remote access.')
+param irNodeRemoteAccessPort int
+
+@description('The expiration time of offline nodes in seconds. The value should not be less than 600.')
+param irNodeExpirationTime int
+
 var managedIdentityName = 'SampleApp'
 
 resource containerRegistry 'Microsoft.ContainerRegistry/registries@2021-06-01-preview' existing = {
@@ -148,6 +154,22 @@ resource app 'Microsoft.Web/sites@2021-03-01' = {
           // The name of the node to create for the self-hosted integration runtime.
           name: 'NODE_NAME'
           value: dataFactoryIntegrationRuntimeNodeName
+        }
+        {
+          name: 'ENABLE_HA'
+          value: 'true'
+        }
+        {
+          name: 'HA_PORT'
+          value: '${irNodeRemoteAccessPort}'
+        }
+        {
+          name: 'ENABLE_AE'
+          value: 'true'
+        }
+        {
+          name: 'AE_TIME'
+          value: '${irNodeExpirationTime}'
         }
       ]
       // Use a user-assigned managed identity to connect to the container registry. (We still need the DOCKER_REGISTRY_SERVER_* settings in the appSettings array, though.)


### PR DESCRIPTION
Enable high-availability and auto-expiration to avoid nodes leak when restart the app service